### PR TITLE
Allow unshare(CLONE_NEWUSER|CLONE_NEWNS|CLONE_NEWUTS) syscall

### DIFF
--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -649,6 +649,34 @@ func DefaultProfile() *Seccomp {
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names: []string{
+					"unshare",
+				},
+				Action: specs.ActAllow,
+				Args: []specs.LinuxSeccompArg{
+					{
+						Index:    0,
+						Value:    unix.CLONE_NEWNS,
+						ValueTwo: 0,
+						Op:       specs.OpMaskedEqual,
+					},
+					{
+						Index:    0,
+						Value:    unix.CLONE_NEWUTS,
+						ValueTwo: 0,
+						Op:       specs.OpMaskedEqual,
+					},
+					{
+						Index:    0,
+						Value:    unix.CLONE_NEWUSER,
+						ValueTwo: 0,
+						Op:       specs.OpMaskedEqual,
+					},
+				},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names: []string{
 					"clone",
 				},
 				Action: specs.ActAllow,


### PR DESCRIPTION
This syscall is required for multiple usecases, one of them is [Buildah](https://github.com/containers/buildah).

See https://github.com/moby/moby/issues/42441

Also, see https://github.com/containers/buildah/blob/b74149334e3ca3d1898f4e46f4ea94db60d14eaa/chroot/run_linux.go#L152-L160

Tested by building Moby with these changes and successfully running Buildah inside Docker.

Without these changes, it fails:

```
$ docker run --rm -it quay.io/buildah/stable:latest buildah
Error during unshare(CLONE_NEWUSER): Operation not permitted
ERRO[0000] parsing PID "": strconv.Atoi: parsing "": invalid syntax 
ERRO[0000] (Unable to determine exit status)
```