### PR TITLE
apparmor: explicitly set abi/3.0

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -11,7 +11,17 @@ package apparmor
 //       profile will likely affect libpod and containerd).
 
 // baseTemplate defines the default apparmor profile for containers.
+//
+// It explicitly sets the AppArmor ABI to 3.0. In AppArmor ABI higher than 4.0,
+// "network" no longer includes "network unix", resulting in access to unix sockets
+// being denied. We use ABI 3.0 to account for some LTS distros that do not
+// yet support ABI 4.0.
+//
+// See https://gitlab.com/apparmor/apparmor/-/issues/561
+// And https://github.com/containerd/containerd/issues/12726
 const baseTemplate = `
+abi <abi/3.0>,
+
 {{range $value := .Imports}}
 {{$value}}
 {{end}}


### PR DESCRIPTION
relates to:

- https://github.com/containerd/containerd/issues/12726
- https://github.com/containerd/containerd/pull/12864
- https://gitlab.com/apparmor/apparmor/-/issues/561


### apparmor: explicitly set abi/3.0

This explicitly sets the AppArmor ABI to 3.0. In AppArmor ABI higher than 4.0, `network` no longer includes `network unix`, resulting in access to unix sockets being denied (also see https://gitlab.com/apparmor/apparmor/-/issues/561):

    apparmor="DENIED" operation="create" class="net" info="failed protocol match" error=-13 profile="cri>

The recommendation is to either pin to abi `<abi/4.0>`, in the policy or to update it to use the newer syntax. Given that we need to account for some LTS distros that do not yet support ABI 4.0, we pin to ABI 3.0.

This is a similar patch as was included in containerd ([containerd@a6f03a7]). From that patch:

> This change sets the AppArmor policy used by containerd to indicate it
> is `abi/3.0`. This was chosen based on some code archeology which
> indicated that containerd 1.7 came out in March 2023, before the
> AppArmor 4.0 ABI. The AppArmor policies themselves date to much older;
> the last apparmor version-checks were removed in [containerd@4baa187]
> and [containerd@c990e3f], and both were looking for AppArmor 2.8.96 or
> older, pointing to abi/3.0 being the "correct" one to pick.
>
> Nothing is preventing containerd from migrating to a newer AppArmor
> ABI; note, however, that anything newer than `abi/4.0` will need
> modifications to preserve UNIX domain sockets.

[containerd@4baa187]: https://github.com/containerd/containerd/commit/4baa1876ba45ffdab9059753215aa1c5d6f79b1d
[containerd@c990e3f]: https://github.com/containerd/containerd/commit/c990e3f2ed88637ac084d32c08f658b211298b61
[containerd@a6f03a7]: https://github.com/containerd/containerd/commit/a6f03a7d56411648c2e97085ae8e120120c06b6b