### PR TITLE
apparmor: align ptrace rule formatting and comment with containerd

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -55,7 +55,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/devices/virtual/powercap/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read,tracedby,readby) peer={{.Name}},
+  # allow processes within the container to trace each other,
+  # provided all other LSM and yama setting allow it.
+  ptrace (trace,tracedby,read,readby) peer={{.Name}},
 }
 `


### PR DESCRIPTION
Use the same formatting and comment as used by the containerd fork for easier comparing the profiles. Using the formatting from [containerd@8d868da].

> Add ptrace readby and tracedby to default AppArmor profile
>
> The default profile allows processes within the container to trace others,
> but blocks reads/traces. This means that diagnostic facilities in processes
> can't easily collect crash/hang dumps. A usual workflow used by solutions
> like crashpad and similar projects is that the process that's unresponsive
> will spawn a process to collect diagnostic data using ptrace. seccomp-bpf,
> yama ptrace settings, and CAP_SYS_PTRACE already provide security mechanisms
> to reduce the scopes in which the API can be used. This enables reading from
> /proc/* files provided the tracer process passes all other checks.

[containerd@8d868da]: https://github.com/containerd/containerd/commit/8d868dadb746aabfd3583d834510109afe9b1919