### PR TITLE
seccomp: Block AF_ALG in default socket policy

### DIFF
--- a/seccomp/default.json
+++ b/seccomp/default.json
@@ -444,8 +444,34 @@
 			"args": [
 				{
 					"index": 0,
+					"value": 38,
+					"op": "SCMP_CMP_LT"
+				}
+			]
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 39,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
 					"value": 40,
-					"op": "SCMP_CMP_NE"
+					"op": "SCMP_CMP_GT"
 				}
 			]
 		},

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -434,6 +434,12 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
+		// Allow socket(2) for all address families except AF_VSOCK.
+		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
+		// allowed unconditionally above, so AF_VSOCK is still reachable
+		// via the socketcall-based socket() path. These arg filters only apply
+		// to the direct socket syscall, and do not protect 32-bit x86 unless
+		// socketcall(2) is also addressed.
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names:  []string{"socket"},

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -434,9 +434,9 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
-		// Allow socket(2) for all address families except AF_VSOCK.
+		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
 		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
-		// allowed unconditionally above, so AF_VSOCK is still reachable
+		// allowed unconditionally above, so AF_VSOCK/AF_ALG is still reachable
 		// via the socketcall-based socket() path. These arg filters only apply
 		// to the direct socket syscall, and do not protect 32-bit x86 unless
 		// socketcall(2) is also addressed.
@@ -447,8 +447,34 @@ func DefaultProfile() *Seccomp {
 				Args: []specs.LinuxSeccompArg{
 					{
 						Index: 0,
+						Value: unix.AF_ALG,
+						Op:    specs.OpLessThan,
+					},
+				},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:  []string{"socket"},
+				Action: specs.ActAllow,
+				Args: []specs.LinuxSeccompArg{
+					{
+						Index: 0,
+						Value: unix.AF_ALG + 1,
+						Op:    specs.OpEqualTo,
+					},
+				},
+			},
+		},
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:  []string{"socket"},
+				Action: specs.ActAllow,
+				Args: []specs.LinuxSeccompArg{
+					{
+						Index: 0,
 						Value: unix.AF_VSOCK,
-						Op:    specs.OpNotEqual,
+						Op:    specs.OpGreaterThan,
 					},
 				},
 			},

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -8,6 +8,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// The socket rules in DefaultProfile rely on AF_ALG and AF_VSOCK being
+// exactly two apart (38 and 40), with a single family (39) between them.
+var (
+	_ [38]byte = [unix.AF_ALG]byte{}
+	_ [40]byte = [unix.AF_VSOCK]byte{}
+	_ [1]byte  = [unix.AF_VSOCK - unix.AF_ALG - 1]byte{}
+)
+
 func arches() []Architecture {
 	return []Architecture{
 		{


### PR DESCRIPTION
Addresses `CVE-2026-31431`.

AF_ALG (address family 38) exposes the Linux kernel crypto API to
userspace via socket(2). Containers have no legitimate need for this
interface under the default profile, and leaving it accessible widens
the kernel attack surface unnecessarily.

This is related to https://copy.fail/ which demonstrates practical
exploitation of AF_ALG to achieve container escape.

The previous socket rule used a single "arg0 != AF_VSOCK" condition.

Naively adding a second OpNotEqual for AF_ALG does not work: seccomp
evaluates multiple argument conditions within a single rule as a logical
AND, so "arg0 != 38 AND arg0 != 40" requires two comparisons against
the same argument index, which libseccomp does not support reliably in
one rule. Splitting into separate deny-action rules also fails because
any matching allow rule takes precedence in seccomp first-match-wins
evaluation.

Instead, restructure the socket allowlist into three range-based rules
that cover every domain except AF_ALG (38) and AF_VSOCK (40):

1. Allow socket when arg0 < 38   (all families below AF_ALG)
2. Allow socket when arg0 == 39  (the single family between them)
3. Allow socket when arg0 > 40   (all families above AF_VSOCK)

Domains 38 and 40 match none of the three rules and fall through to the
default SCMP_ACT_ERRNO action.