### PR TITLE
seccomp: Explicitly block socketcall to prevent AF_ALG filter bypass

### DIFF
--- a/seccomp/default.json
+++ b/seccomp/default.json
@@ -371,7 +371,6 @@
 				"signalfd4",
 				"sigprocmask",
 				"sigreturn",
-				"socketcall",
 				"socketpair",
 				"splice",
 				"stat",
@@ -435,6 +434,13 @@
 			"includes": {
 				"minKernel": "4.8"
 			}
+		},
+		{
+			"names": [
+				"socketcall"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38
 		},
 		{
 			"names": [

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -374,7 +374,6 @@ func DefaultProfile() *Seccomp {
 					"signalfd4",
 					"sigprocmask",
 					"sigreturn",
-					"socketcall",
 					"socketpair",
 					"splice",
 					"stat",
@@ -442,12 +441,27 @@ func DefaultProfile() *Seccomp {
 				MinKernel: &KernelVersion{4, 8},
 			},
 		},
+		// socketcall(2) is explicitly denied to prevent bypassing the socket
+		// address family filters above on architectures where socketcall is
+		// supported (i386, s390, MIPS o32).
+		// Seccomp cannot inspect socketcall's pointer argument, so allowing it
+		// would let an attacker open AF_ALG sockets via socketcall(SYS_SOCKET,
+		// ...). Since Linux 4.3 all affected architectures provide direct
+		// socket syscalls, so modern userspace is not impacted.
+		//
+		// ENOSYS (not EPERM) is used because the errno must differ from
+		// DefaultErrnoRet; otherwise both runc and libseccomp treat the rule
+		// as identical to the default action and silently omit it from the
+		// generated BPF, which lets libseccomp's auto-generated
+		// socketcall(SYS_SOCKET) -> ALLOW path survive unchallenged.
+		{
+			LinuxSyscall: specs.LinuxSyscall{
+				Names:    []string{"socketcall"},
+				Action:   specs.ActErrno,
+				ErrnoRet: &nosys,
+			},
+		},
 		// Allow socket(2) for all address families except AF_VSOCK and AF_ALG.
-		// NOTE: on 32-bit x86, socket() goes through socketcall(2) which is
-		// allowed unconditionally above, so AF_VSOCK/AF_ALG is still reachable
-		// via the socketcall-based socket() path. These arg filters only apply
-		// to the direct socket syscall, and do not protect 32-bit x86 unless
-		// socketcall(2) is also addressed.
 		{
 			LinuxSyscall: specs.LinuxSyscall{
 				Names:  []string{"socket"},


### PR DESCRIPTION
- follow up to: https://github.com/moby/profiles/pull/20

The socket arg filters that block AF_ALG and AF_VSOCK only apply to the direct socket(2) syscall. On architectures with the legacy socketcall(2) multiplexer (i386, s390, MIPS o32), libseccomp auto-generates a socketcall(SYS_SOCKET) -> ALLOW companion for each socket ALLOW rule. This companion only checks the socketcall sub-command number, not the address family (behind a pointer BPF cannot dereference), bypassing the AF_ALG block for 32-bit binaries.

Add an explicit socketcall -> ERRNO(ENOSYS) deny rule placed before the socket allow rules. ENOSYS must be used instead of EPERM because the deny errno must differ from DefaultErrnoRet (EPERM): runc skips calling seccomp_rule_add() entirely when a rule's action matches the default action, so an EPERM deny is never passed to libseccomp and the auto-generated socketcall ALLOW path survives unchallenged. With ENOSYS, runc passes the rule through, and libseccomp replaces the auto-generated ALLOW path with ERRNO(ENOSYS) in the BPF.

Since Linux 4.3, all affected architectures provide direct socket syscalls and modern glibc/musl already use them. Only very old statically-linked 32-bit binaries compiled against pre-4.3 glibc would be affected.
