### PR TITLE
apparmor: Deny AF_ALG sockets in default container profile

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -32,6 +32,8 @@ profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
 {{- end}}{{if .InnerImports}}
 {{end}}
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/default.golden
+++ b/apparmor/testdata/default.golden
@@ -5,6 +5,8 @@
 
 profile "default" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-abstractions-base.golden
+++ b/apparmor/testdata/with-abstractions-base.golden
@@ -7,6 +7,8 @@ profile "abstractions-base" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-api3.golden
+++ b/apparmor/testdata/with-api3.golden
@@ -5,6 +5,8 @@ abi <abi/3.0>,
 
 profile "with-api3" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-custom-imports.golden
+++ b/apparmor/testdata/with-custom-imports.golden
@@ -7,6 +7,8 @@
 
 profile "custom-imports" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-custom-inner-imports.golden
+++ b/apparmor/testdata/with-custom-inner-imports.golden
@@ -8,6 +8,8 @@ profile "custom-inner-imports" flags=(attach_disconnected,mediate_deleted) {
   #include <something/bar>
 
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-daemon-profile.golden
+++ b/apparmor/testdata/with-daemon-profile.golden
@@ -5,6 +5,8 @@
 
 profile "with-daemon-profile" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-spaces.golden
+++ b/apparmor/testdata/with-spaces.golden
@@ -5,6 +5,8 @@
 
 profile "Profile with spaces" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-tunables.golden
+++ b/apparmor/testdata/with-tunables.golden
@@ -5,6 +5,8 @@
 
 profile "tunables" flags=(attach_disconnected,mediate_deleted) {
   network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
   capability,
   file,
   umount,


### PR DESCRIPTION
### apparmor: Deny AF_ALG sockets in default container profile

  The AF_ALG address family exposes the Linux kernel crypto API to userspace via sockets. This has been a source of container escape vulnerabilities (see https://copy.fail/).

  Unlike seccomp, which can only filter arguments of the direct socket(2) syscall, AppArmor hooks into the kernel's security_socket_create() LSM callback, which fires regardless of the syscall entry point. This means AppArmor also blocks AF_ALG sockets created via the legacy socketcall(2) multiplexer (used by 32-bit binaries), which seccomp cannot inspect because the address family is behind a userspace pointer that BPF cannot dereference.

  The "deny network alg," rule is placed right after the blanket
  "network," allow rule so the deny takes precedence for this specific address family.