### PR TITLE
seccomp: always include runtime arch in resulting profile

### DIFF
--- a/seccomp/default.json
+++ b/seccomp/default.json
@@ -56,6 +56,18 @@
 		{
 			"architecture": "SCMP_ARCH_LOONGARCH64",
 			"subArchitectures": null
+		},
+		{
+			"architecture": "SCMP_ARCH_PPC64LE",
+			"subArchitectures": null
+		},
+		{
+			"architecture": "SCMP_ARCH_PPC64",
+			"subArchitectures": null
+		},
+		{
+			"architecture": "SCMP_ARCH_PPC",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -54,6 +54,18 @@ func arches() []Architecture {
 			Arch:      specs.ArchLOONGARCH64,
 			SubArches: nil,
 		},
+		{
+			Arch:      specs.ArchPPC64LE,
+			SubArches: nil,
+		},
+		{
+			Arch:      specs.ArchPPC64,
+			SubArches: nil,
+		},
+		{
+			Arch:      specs.ArchPPC,
+			SubArches: nil,
+		},
 	}
 }
 

--- a/seccomp/seccomp_linux.go
+++ b/seccomp/seccomp_linux.go
@@ -103,6 +103,12 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 				break
 			}
 		}
+		// Ensure the runtime arch is in the profile so libseccomp returns
+		// -ENOSYS (letting glibc fall back to older syscalls) instead of -EPERM
+		// for syscalls unknown to the profile.
+		if !slices.Contains(newConfig.Architectures, seccompArch) {
+			newConfig.Architectures = append(newConfig.Architectures, seccompArch)
+		}
 	}
 
 Loop:

--- a/seccomp/seccomp_linux_test.go
+++ b/seccomp/seccomp_linux_test.go
@@ -5,8 +5,11 @@ package seccomp
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"reflect"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -35,6 +38,7 @@ func TestLoadProfile(t *testing.T) {
 	expected := specs.LinuxSeccomp{
 		DefaultAction:   specs.ActErrno,
 		DefaultErrnoRet: &expectedDefaultErrno,
+		Architectures:   runtimeArchSlice(),
 		Syscalls: []specs.LinuxSyscall{
 			{
 				Names:  []string{"clone"},
@@ -83,6 +87,7 @@ func TestLoadProfileWithDefaultErrnoRet(t *testing.T) {
 	expected := specs.LinuxSeccomp{
 		DefaultAction:   specs.ActErrno,
 		DefaultErrnoRet: &expectedErrnoRet,
+		Architectures:   runtimeArchSlice(),
 	}
 
 	assertDeepEqual(t, expected, *p)
@@ -102,6 +107,7 @@ func TestLoadProfileWithListenerPath(t *testing.T) {
 
 	expected := specs.LinuxSeccomp{
 		DefaultAction:    specs.ActErrno,
+		Architectures:    runtimeArchSlice(),
 		ListenerPath:     "/var/run/seccompaget.sock",
 		ListenerMetadata: "opaque-metadata",
 	}
@@ -113,6 +119,7 @@ func TestLoadProfileWithFlag(t *testing.T) {
 	profile := `{"defaultAction": "SCMP_ACT_ERRNO", "flags": ["SECCOMP_FILTER_FLAG_SPEC_ALLOW", "SECCOMP_FILTER_FLAG_LOG"]}`
 	expected := specs.LinuxSeccomp{
 		DefaultAction: specs.ActErrno,
+		Architectures: runtimeArchSlice(),
 		Flags:         []specs.LinuxSeccompFlag{"SECCOMP_FILTER_FLAG_SPEC_ALLOW", "SECCOMP_FILTER_FLAG_LOG"},
 	}
 	rs := createSpec()
@@ -171,6 +178,9 @@ func TestLoadLegacyProfile(t *testing.T) {
 		t.Fatalf("expected default action %s, got %s", specs.ActErrno, p.DefaultAction)
 	}
 	expectedArches := []specs.Arch{"SCMP_ARCH_X86_64", "SCMP_ARCH_X86", "SCMP_ARCH_X32"}
+	if runtimeArch, ok := nativeToSeccomp[goToNative[runtime.GOARCH]]; ok && !slices.Contains(expectedArches, runtimeArch) {
+		expectedArches = append(expectedArches, runtimeArch)
+	}
 	assertDeepEqual(t, expectedArches, p.Architectures)
 
 	if expected := 311; len(p.Syscalls) != expected {
@@ -299,6 +309,121 @@ func TestLoadConditional(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetupSeccompRuntimeArchAlwaysIncluded(t *testing.T) {
+	runtimeArch, ok := nativeToSeccomp[goToNative[runtime.GOARCH]]
+	if !ok {
+		t.Skipf("no seccomp arch mapping for GOARCH=%s", runtime.GOARCH)
+	}
+
+	otherArch := specs.ArchMIPS
+	if otherArch == runtimeArch {
+		otherArch = specs.ArchS390
+	}
+
+	t.Run("empty architectures get runtime arch added", func(t *testing.T) {
+		rs := createSpec()
+		p, err := LoadProfile(`{"defaultAction":"SCMP_ACT_ERRNO","architectures":[]}`, &rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(p.Architectures, runtimeArch) {
+			t.Fatalf("expected runtime arch %q in architectures, got %v", runtimeArch, p.Architectures)
+		}
+	})
+
+	t.Run("foreign architectures get runtime arch appended", func(t *testing.T) {
+		profile := fmt.Sprintf(`{"defaultAction":"SCMP_ACT_ERRNO","architectures":[%q]}`, string(otherArch))
+		rs := createSpec()
+		p, err := LoadProfile(profile, &rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(p.Architectures, runtimeArch) {
+			t.Fatalf("expected runtime arch %q in architectures, got %v", runtimeArch, p.Architectures)
+		}
+		if !slices.Contains(p.Architectures, otherArch) {
+			t.Fatalf("expected %q to remain in architectures, got %v", otherArch, p.Architectures)
+		}
+	})
+
+	t.Run("runtime arch already present is not duplicated", func(t *testing.T) {
+		profile := fmt.Sprintf(`{"defaultAction":"SCMP_ACT_ERRNO","architectures":[%q]}`, string(runtimeArch))
+		rs := createSpec()
+		p, err := LoadProfile(profile, &rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, a := range p.Architectures {
+			if a == runtimeArch {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected runtime arch %q exactly once, got %d (architectures: %v)", runtimeArch, count, p.Architectures)
+		}
+	})
+
+	t.Run("archMap-supplied runtime arch is not duplicated", func(t *testing.T) {
+		profile := fmt.Sprintf(
+			`{"defaultAction":"SCMP_ACT_ERRNO","archMap":[{"architecture":%q,"subArchitectures":[]}]}`,
+			string(runtimeArch),
+		)
+		rs := createSpec()
+		p, err := LoadProfile(profile, &rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, a := range p.Architectures {
+			if a == runtimeArch {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected runtime arch %q exactly once after archMap expansion, got %d (architectures: %v)", runtimeArch, count, p.Architectures)
+		}
+	})
+}
+
+func TestArchesIncludesPPC(t *testing.T) {
+	got := arches()
+	for _, want := range []specs.Arch{specs.ArchPPC64LE, specs.ArchPPC64, specs.ArchPPC} {
+		found := false
+		for _, a := range got {
+			if a.Arch == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("arches() missing %q", want)
+		}
+	}
+}
+
+func TestGetDefaultProfileIncludesRuntimeArch(t *testing.T) {
+	runtimeArch, ok := nativeToSeccomp[goToNative[runtime.GOARCH]]
+	if !ok {
+		t.Skipf("no seccomp arch mapping for GOARCH=%s", runtime.GOARCH)
+	}
+	rs := createSpec()
+	p, err := GetDefaultProfile(&rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(p.Architectures, runtimeArch) {
+		t.Fatalf("expected default profile to include runtime arch %q, got %v", runtimeArch, p.Architectures)
+	}
+}
+
+func runtimeArchSlice() []specs.Arch {
+	if a, ok := nativeToSeccomp[goToNative[runtime.GOARCH]]; ok {
+		return []specs.Arch{a}
+	}
+	return nil
 }
 
 // createSpec() creates a minimum spec for testing


### PR DESCRIPTION
Profiles whose `architectures` list omits the runtime architecture (and default profiles on architectures not listed in `arches()` — most notably the PPC family) cause syscalls unknown to libseccomp to return `-EPERM` instead of the `-ENOSYS` stub libcontainer expects. glibc relies on `-ENOSYS` to fall back to older syscalls; without it, simple operations like `chmod -R` fail on ppc64le containers (e.g. `fchmodat2` -> EPERM on Debian sid; reported in moby/moby#48471 by @grooverdan via `dh_installdocs` on a MariaDB build).

Mirrors the analogous runc fix in opencontainers/runc#4219:

- `seccomp/default_linux.go`: add the PPC family (PPC64LE, PPC64, PPC) to the architectures bundled into the default profile.
- `seccomp/seccomp_linux.go`: append the runtime arch to the resolved profile when it is not already present, so user-supplied profiles which set `"architectures"` explicitly still get the ENOSYS stub for the host.
- `seccomp/default.json`: regenerated via `go generate ./seccomp/`.

Tests cover: an empty `"architectures"` list, a foreign-arch list, an already-present runtime arch (de-dup), and an archMap that supplied the runtime arch (de-dup via `slices.Contains`). A host-agnostic test asserts the PPC entries in `arches()` so amd64 CI catches regressions too.

Locally verified via `docker run --platform=linux/{amd64,arm64,ppc64le,s390x} golang:1.23 go test ./seccomp/...` — all pass.

---

Created with: Claude Code (Opus 4.7)