### PR TITLE
update SPDX headers to better match the specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright The Moby Authors.
+# SPDX-FileCopyrightText: Copyright The Moby Authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Makefile for building and testing Moby profiles packages

--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux

--- a/apparmor/apparmor_linux_test.go
+++ b/apparmor/apparmor_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package apparmor

--- a/apparmor/go.mod
+++ b/apparmor/go.mod
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/moby/profiles/apparmor

--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux

--- a/script/validate/default-seccomp
+++ b/script/validate/default-seccomp
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright The Moby Authors.
+# SPDX-FileCopyrightText: Copyright The Moby Authors
 # SPDX-License-Identifier: Apache-2.0
 
 # This script validates that the seccomp profile generation is done correctly.

--- a/script/validate/template/bash.txt
+++ b/script/validate/template/bash.txt
@@ -1,2 +1,2 @@
-# Copyright The Moby Authors.
+# SPDX-FileCopyrightText: Copyright The Moby Authors
 # SPDX-License-Identifier: Apache-2.0

--- a/script/validate/template/go.txt
+++ b/script/validate/template/go.txt
@@ -1,2 +1,2 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/script/validate/template/makefile.txt
+++ b/script/validate/template/makefile.txt
@@ -1,2 +1,2 @@
-# Copyright The Moby Authors.
+# SPDX-FileCopyrightText: Copyright The Moby Authors
 # SPDX-License-Identifier: Apache-2.0

--- a/seccomp/default_linux.go
+++ b/seccomp/default_linux.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package seccomp

--- a/seccomp/generate.go
+++ b/seccomp/generate.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build ignore

--- a/seccomp/go.mod
+++ b/seccomp/go.mod
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/moby/profiles/seccomp

--- a/seccomp/kernel_linux.go
+++ b/seccomp/kernel_linux.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package seccomp

--- a/seccomp/kernel_linux_test.go
+++ b/seccomp/kernel_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package seccomp

--- a/seccomp/seccomp.go
+++ b/seccomp/seccomp.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package seccomp

--- a/seccomp/seccomp_linux.go
+++ b/seccomp/seccomp_linux.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:generate go run -tags 'seccomp' generate.go

--- a/seccomp/seccomp_linux_test.go
+++ b/seccomp/seccomp_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright The Moby Authors.
+// SPDX-FileCopyrightText: Copyright The Moby Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package seccomp


### PR DESCRIPTION
commit 4f000411b32446c549d57cf82bf7481dda67bd45 added SPDX copyright headers to all files, using `Copyright` as a prefix. While this is generally detected correctly, the [REUSE Specification] describes the [SPDX-FileCopyrightText] header/tag as the standard header used for detection;

> ## Format of Copyright Notices
>
> A Copyright Notice MUST start with a tag, word or symbol (collectively:
> prefixes) from the following list:
>
> - `SPDX-FileCopyrightText` (or `SPDX-SnippetCopyrightText` in Snippets)
> - Copyright
> - ©
>
> It is RECOMMENDED to use the `SPDX-FileCopyrightText` tag. You MAY add '(C)',
> '(c)' or '©' after the prefix.

This patch updates the headers to use the recommended `SPDX-FileCopyrightText` tag.

[SPDX-FileCopyrightText]: https://spdx.github.io/spdx-spec/v2.3/file-tags/#h2-file-tags-format
[REUSE Specification]: https://reuse.software/spec-3.3/#format-of-copyright-notices