### PR TITLE
apparmor: Deny AF_VSOCK sockets in default container profile

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -34,6 +34,8 @@ profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/default.golden
+++ b/apparmor/testdata/default.golden
@@ -7,6 +7,8 @@ profile "default" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-abstractions-base.golden
+++ b/apparmor/testdata/with-abstractions-base.golden
@@ -9,6 +9,8 @@ profile "abstractions-base" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-api3.golden
+++ b/apparmor/testdata/with-api3.golden
@@ -7,6 +7,8 @@ profile "with-api3" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-custom-imports.golden
+++ b/apparmor/testdata/with-custom-imports.golden
@@ -9,6 +9,8 @@ profile "custom-imports" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-custom-inner-imports.golden
+++ b/apparmor/testdata/with-custom-inner-imports.golden
@@ -10,6 +10,8 @@ profile "custom-inner-imports" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-daemon-profile.golden
+++ b/apparmor/testdata/with-daemon-profile.golden
@@ -7,6 +7,8 @@ profile "with-daemon-profile" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-spaces.golden
+++ b/apparmor/testdata/with-spaces.golden
@@ -7,6 +7,8 @@ profile "Profile with spaces" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,

--- a/apparmor/testdata/with-tunables.golden
+++ b/apparmor/testdata/with-tunables.golden
@@ -7,6 +7,8 @@ profile "tunables" flags=(attach_disconnected,mediate_deleted) {
   network,
   # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
   deny network alg,
+  # Disallow AF_VSOCK to prevent host/guest communication.
+  deny network vsock,
   capability,
   file,
   umount,


### PR DESCRIPTION
The default seccomp profile excludes AF_VSOCK for direct socket calls, but 32-bit x86 binaries can reach it through socketcall because seccomp cannot inspect the pointer argument.

Deny the family in AppArmor so the socket_create LSM hook closes that path and prevents default-profile containers from reaching host or guest VSOCK services.